### PR TITLE
Add SignalR video hub and upload endpoint

### DIFF
--- a/WebSocket/Controllers/VideoController.cs
+++ b/WebSocket/Controllers/VideoController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using WebSocket.Hubs;
+
+namespace WebSocket.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class VideoController : ControllerBase
+{
+    private readonly IHubContext<VideoHub> _hubContext;
+
+    public VideoController(IHubContext<VideoHub> hubContext)
+    {
+        _hubContext = hubContext;
+    }
+
+    /// <summary>
+    /// Accepts a video file and broadcasts it to all connected SignalR clients.
+    /// </summary>
+    /// <param name="video">The uploaded video file.</param>
+    [HttpPost("upload")]
+    [RequestSizeLimit(long.MaxValue)]
+    [RequestFormLimits(MultipartBodyLengthLimit = long.MaxValue)]
+    public async Task<IActionResult> Upload([FromForm] IFormFile? video)
+    {
+        if (video is null || video.Length == 0)
+        {
+            return BadRequest("No video file was uploaded.");
+        }
+
+        await using var memoryStream = new MemoryStream();
+        await video.CopyToAsync(memoryStream);
+        var base64Video = Convert.ToBase64String(memoryStream.ToArray());
+
+        await _hubContext.Clients.All.SendAsync("ReceiveVideo", new
+        {
+            fileName = video.FileName,
+            contentType = video.ContentType,
+            data = base64Video,
+            length = video.Length
+        });
+
+        return Ok(new
+        {
+            video.FileName,
+            video.ContentType,
+            video.Length
+        });
+    }
+}

--- a/WebSocket/Hubs/VideoHub.cs
+++ b/WebSocket/Hubs/VideoHub.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace WebSocket.Hubs;
+
+public class VideoHub : Hub
+{
+}

--- a/WebSocket/Program.cs
+++ b/WebSocket/Program.cs
@@ -1,23 +1,34 @@
+using Microsoft.OpenApi.Models;
+using WebSocket.Hubs;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "WebSocket API",
+        Version = "v1",
+        Description = "APIs for broadcasting uploaded videos to SignalR clients."
+    });
+});
+
+builder.Services.AddSignalR();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+app.UseSwagger();
+app.UseSwaggerUI(options =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+    options.SwaggerEndpoint("/swagger/v1/swagger.json", "WebSocket API v1");
+    options.RoutePrefix = string.Empty;
+});
 
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapHub<VideoHub>("/hubs/video");
 
 app.Run();


### PR DESCRIPTION
## Summary
- configure Swagger with descriptive metadata and expose the UI in every environment
- add a SignalR video hub and map it under the `/hubs/video` route
- implement a video upload API that broadcasts uploaded files to connected clients through the hub

## Testing
- dotnet build *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d189b615d88332ac5d0a6945ef422e