### PR TITLE
Broadcast static video to SignalR clients

### DIFF
--- a/WebSocket/Options/StaticVideoOptions.cs
+++ b/WebSocket/Options/StaticVideoOptions.cs
@@ -1,0 +1,12 @@
+namespace WebSocket.Options;
+
+public class StaticVideoOptions
+{
+    public const string SectionName = "StaticVideo";
+
+    /// <summary>
+    /// Relative path to the file inside the application's <c>wwwroot</c> directory
+    /// that should be broadcast to connected clients.
+    /// </summary>
+    public string RelativePath { get; set; } = string.Empty;
+}

--- a/WebSocket/Program.cs
+++ b/WebSocket/Program.cs
@@ -1,7 +1,10 @@
 using Microsoft.OpenApi.Models;
 using WebSocket.Hubs;
+using WebSocket.Options;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<StaticVideoOptions>(builder.Configuration.GetSection(StaticVideoOptions.SectionName));
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -11,7 +14,7 @@ builder.Services.AddSwaggerGen(options =>
     {
         Title = "WebSocket API",
         Version = "v1",
-        Description = "APIs for broadcasting uploaded videos to SignalR clients."
+        Description = "APIs for broadcasting videos to SignalR clients."
     });
 });
 
@@ -25,6 +28,8 @@ app.UseSwaggerUI(options =>
     options.SwaggerEndpoint("/swagger/v1/swagger.json", "WebSocket API v1");
     options.RoutePrefix = string.Empty;
 });
+
+app.UseStaticFiles();
 
 app.UseAuthorization();
 

--- a/WebSocket/appsettings.json
+++ b/WebSocket/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "StaticVideo": {
+    "RelativePath": "videos/sample.mp4"
+  }
 }


### PR DESCRIPTION
## Summary
- broadcast a pre-configured static video from wwwroot instead of accepting uploads
- bind static video options from configuration and expose placeholder directory under wwwroot
- enable static file middleware so the application can serve the configured assets

## Testing
- dotnet build *(fails: `dotnet` command not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d18f0b95c08332818f7c264ec6d48f