### PR TITLE
Add Docker and docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+# Configure ASP.NET Core to listen on port 8080
+ENV ASPNETCORE_URLS=http://+:8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy project files and restore dependencies
+COPY WebSocket/WebSocket.csproj WebSocket/
+RUN dotnet restore WebSocket/WebSocket.csproj
+
+# Copy the rest of the source code and build the application
+COPY . .
+WORKDIR /src/WebSocket
+RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish ./
+ENTRYPOINT ["dotnet", "WebSocket.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+
+services:
+  websocketapi:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for building and running the ASP.NET Core project
- configure docker-compose to build the image and expose the application on port 8080

## Testing
- not run (Docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1a08315e883329771e0c277b59ffa